### PR TITLE
Search for both basic and bottleneck blocks (to fix "no known network structure detected" warning with ResNet-50 and other similar models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See the [Annealing](http://dev.fast.ai/callback.schedule#Annealing) section of f
 `ManifoldMixup` tries to establish a sensible list of modules on which to apply mixup:
 - it uses a user provided `module_list` if possible
 - otherwise it uses only the modules wrapped with `ManifoldMixupModule`
-- if none are found, it defaults to modules with `Block` in their name (targetting mostly resblocks)
+- if none are found, it defaults to modules with `Block` or `Bottleneck` in their name (targetting mostly resblocks)
 - finaly, if needed, it defaults to all modules that are not included in the `non_mixable_module_types` list
 
 The `non_mixable_module_types` list contains mostly recurrent layers but you can add elements to it in order to define module classes that should not be used for mixup (*do not hesitate to create an issue or start a PR to add common modules to the default list*).

--- a/manifold_mixup.py
+++ b/manifold_mixup.py
@@ -9,7 +9,6 @@ from fastai2.callback.mixup import reduce_loss
 from fastai2.text.models import AWD_LSTM
 from fastai2.vision.models.unet import UnetBlock
 from fastai2.tabular.model import TabularModel
-from re import search
 
 __all__ = ['ManifoldMixupModule', 'ManifoldMixup', 'OutputMixup', 'non_mixable_module_types']
 
@@ -40,8 +39,9 @@ def _is_mixable(m):
     return not any(isinstance(m, non_mixable_class) for non_mixable_class in non_mixable_module_types)
 
 def _is_block_module(m):
-    "Checks wether a module is a Block (typically a kind of resBlock)"
-    return bool(search(r"(?i)block|bottleneck", str(type(m))))
+    "Checks whether a module is a Block or Bottleneck (typically a kind of resBlock)"
+    m = str(type(m)).lower()
+    return "block" in m or "bottleneck" in m
 
 def _get_mixup_module_list(model):
     "returns all the modules that can be used for mixup"

--- a/manifold_mixup.py
+++ b/manifold_mixup.py
@@ -9,6 +9,7 @@ from fastai2.callback.mixup import reduce_loss
 from fastai2.text.models import AWD_LSTM
 from fastai2.vision.models.unet import UnetBlock
 from fastai2.tabular.model import TabularModel
+from re import search
 
 __all__ = ['ManifoldMixupModule', 'ManifoldMixup', 'OutputMixup', 'non_mixable_module_types']
 
@@ -40,7 +41,7 @@ def _is_mixable(m):
 
 def _is_block_module(m):
     "Checks wether a module is a Block (typically a kind of resBlock)"
-    return "block" in str(type(m)).lower()
+    return bool(search(r"(?i)block|bottleneck", str(type(m))))
 
 def _get_mixup_module_list(model):
     "returns all the modules that can be used for mixup"


### PR DESCRIPTION
Currently when trying to use ResNet-50 (the same issue happens with usual
ResNeSt-50 and many other similar models) from timm library
https://github.com/rwightman/pytorch-image-models, I get the following warning:

"Manifold mixup: no known network structure detected, 126 modules will be used
for mixup"

This happens because ResNet-50 and higher do not have any BasicBlock and have
Bottlenecks instead. With this patch I get this message:

"Manifold mixup: Block structure detected, 16 modules will be used for mixup."

I get better error_rate than when 126 modules were used for mixup.