### PR TITLE
Add support for mixed precision (fixes #1)

### DIFF
--- a/manifold_mixup.py
+++ b/manifold_mixup.py
@@ -140,7 +140,9 @@ class ManifoldMixup(Callback):
         "Interupt one run to use its intermediate results with a second model call."
         if not self.mixup_has_been_applied: # performs mixup
             output_dims = len(output.size())
+            if hasattr(self.learn, "mixed_precision"): output = output.float()
             output = torch.lerp(output[self.shuffle], output, weight=unsqueeze(self.lam, n=output_dims-1))
+            if hasattr(self.learn, "mixed_precision"): output = output.half()
             self.mixup_has_been_applied = True
             return output
         elif not self.warning_raised:


### PR DESCRIPTION
torch.lerp expects dtype Float and does not accept dtype Half, so it is
necessary to temporally convert output to dType Float.